### PR TITLE
version 0.0.0 in package.json and pyproject.toml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lhp",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "private": true,
   "description": "Asynchronous client for the Länderübergreifendes Hochwasserportal (LHP) API",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lhp"
-version = "0.0.1"
+version = "0.0.0"
 description = "Asynchronous client for the Länderübergreifendes Hochwasserportal (LHP) API."
 authors = ["Karsten Bade <karsten@bade.dev>"]
 maintainers = ["Karsten Bade <karsten@bade.dev>"]


### PR DESCRIPTION
Because versions are managed over workflows instead of configfile

# Proposed Changes

> Version 0.0.0 in Configfiles, because versionmanagement is done over workflows

## Related Issues

> none

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
